### PR TITLE
fix(linter-class): adapt to new sublimelinter version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ install:
 # command to run tests
 script:
   - flake8 . --max-line-length=120
-  - pep257 . --ignore=D202
+  - pep257 . --ignore=D202,D203

--- a/linter.py
+++ b/linter.py
@@ -14,7 +14,6 @@ from SublimeLinter.lint import Linter, util
 
 
 class Sqlint(Linter):
-
     """Provides an interface to sqlint."""
 
     cmd = 'sqlint'

--- a/linter.py
+++ b/linter.py
@@ -18,7 +18,7 @@ class Sqlint(Linter):
     """Provides an interface to sqlint."""
 
     cmd = 'sqlint'
-    syntax = 'sql'
+    defaults = {'selector': 'source.sql'}
     tempfile_suffix = 'sql'
 
     version_args = '--version'


### PR DESCRIPTION
'defaults' is needed, and must contain 'selector'